### PR TITLE
Cow game fix

### DIFF
--- a/src/game/CowGame.tsx
+++ b/src/game/CowGame.tsx
@@ -7,6 +7,7 @@ import sprites2x from "./assets/default_200_percent/200-offline-sprite.png";
 
 import { Runner } from "./model/Runner";
 import { IS_MOBILE } from "./model/const";
+import { devLog } from "./utils";
 
 const STYLES: CSSProperties = {
   textAlign: "center",
@@ -20,11 +21,11 @@ export function CowGame() {
   const hideMessageBox = () => setShowMessageBox(false);
 
   useEffect(() => {
-    console.log("🐮🐮 Loading Cow Runner 🐮🐮");
+    devLog("🐮🐮 Loading Cow Runner 🐮🐮");
 
     // Boot runner
     const runner = new Runner(".interstitial-wrapper", undefined);
-    console.log("Runner", runner);
+    devLog("Runner", runner);
 
     // Mobile/touch device: On touch start hide message box
     // Element doesnt exist until game is initialized
@@ -35,6 +36,7 @@ export function CowGame() {
     }
 
     return () => {
+      messageBox.removeEventListener("touchstart", hideMessageBox)
       runner.destroy();
     };
   }, [hideMessageBox]);

--- a/src/game/utils/index.ts
+++ b/src/game/utils/index.ts
@@ -1,0 +1,3 @@
+export function devLog(...args: any[]) {
+    return process.env.NODE_ENV !== 'production' && console.log(...args)
+}


### PR DESCRIPTION
- Uses better support for touch devices, by setting const `IS_MOBILE` to `'ontouchstart' in window;`. Now you can use Chrome phone emulator to try it out.
- Also shows the right title (Tab to start vs. Press Space to start).

# Issues detected:
- `id="messageBox"` in `CowGame.tsx` L46 is shown even after hideMessageBox is executed. Need to check why the state isn't changed.