### PR TITLE
Starting the game css "jump" fix

### DIFF
--- a/src/game/CowGame.tsx
+++ b/src/game/CowGame.tsx
@@ -12,6 +12,8 @@ import { devLog } from "./utils";
 const STYLES: CSSProperties = {
   textAlign: "center",
   fontFamily: "Open Sans, sans-serif",
+  margin: 0, 
+  height: 0,
 };
 
 export function CowGame() {
@@ -48,7 +50,7 @@ export function CowGame() {
 
   return (
     <div id="main-cowgame">
-      <div id="messageBox" className="sendmessage" style={{ display: showMessageBox ? 'block' : 'none' }}>
+      <div id="messageBox" className="sendmessage" style={{ visibility: showMessageBox ? 'visible' : 'hidden' }}>
         <h1 style={STYLES}>🐮 {startTitle} 🐮</h1>
       </div>
 

--- a/src/game/CowGame.tsx
+++ b/src/game/CowGame.tsx
@@ -48,11 +48,9 @@ export function CowGame() {
 
   return (
     <div id="main-cowgame">
-      {showMessageBox && (
-        <div id="messageBox" className="sendmessage">
-          <h1 style={STYLES}>🐮 {startTitle} 🐮</h1>
-        </div>
-      )}
+      <div id="messageBox" className="sendmessage" style={{ display: showMessageBox ? 'block' : 'none' }}>
+        <h1 style={STYLES}>🐮 {startTitle} 🐮</h1>
+      </div>
 
       <div id="main-frame-error" className="interstitial-wrapper">
         <div id="main-content">


### PR DESCRIPTION
css to stop slight jumping of game on start.

- removes height/margin from h1 as it's not really needed imo. it fits in the game box
- visibility: hidden/visible instead of unmount